### PR TITLE
Implement Product Deletion

### DIFF
--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -1,5 +1,6 @@
 import Products from '../db/products';
 import Responses from '../utils/responseUtils';
+import CloudinaryService from '../services/cloudinaryService';
 
 /**
  * Defines the controllers for the /products endpoint
@@ -12,24 +13,54 @@ export default class ProductController {
    * @param {callback} next
    */
   static async addProduct(request, response, next) {
-    try {
-      const {
-        title, price, priceDenomination, weight, weightUnit, description, images,
-      } = request.body;
-      const { userId: ownerId } = request.user;
-      const newProduct = {
-        ownerId,
-        title: title.trim(),
-        price: { value: price.trim(), denomination: priceDenomination.trim() },
-        weight: { value: weight.trim(), unit: weightUnit.trim() },
-        description: description.trim(),
-        images: images || [],
-      };
+    const {
+      title, price, priceDenomination, weight, weightUnit, description, images,
+    } = request.body;
+    const { userId: ownerId } = request.user;
+    const newProduct = {
+      ownerId,
+      title: title.trim(),
+      price: { value: price.trim(), denomination: priceDenomination.trim() },
+      weight: { value: weight.trim(), unit: weightUnit.trim() },
+      description: description.trim(),
+      images: images || [],
+    };
 
+    try {
       const product = await Products.addProduct(newProduct);
       Responses.success(response, product, 201);
     } catch (error) {
       next(new Error());
+    }
+  }
+
+  /**
+   * Deletes a product and all associated resources from the db
+   * @param {object} request
+   * @param {object} response
+   * @param {callback} next
+   * @returns {object} response
+   */
+  static async deleteProduct(request, response, next) {
+    const { userId } = request.user;
+    const { productId } = request.params;
+    try {
+      // Ensure the product exists else return a 404 error
+      const product = await Products.getProduct(productId);
+      if (!product) return Responses.notFoundError(response, 'Product not found');
+      // Ensure the user has permission to delete the product (this may feel unnecessary now but
+      // preparing for when there'll be need to scale)
+      if (product.ownerId !== userId) {
+        return Responses.forbiddenError(response, 'You are not permitted to delete the product');
+      }
+      // If there are images delete them from the third party service
+      if (product.images.length) await CloudinaryService.deleteImages(product.images);
+
+      // Delete from the records
+      await Products.deleteProduct(productId);
+      return Responses.success(response, { message: `"${product.title}" successfully deleted` });
+    } catch (error) {
+      next(new Error('Internal server error'));
     }
   }
 }

--- a/src/db/products.js
+++ b/src/db/products.js
@@ -1,4 +1,5 @@
-const products = [
+/* eslint-disable eqeqeq */
+let products = [
   {
     id: 1,
     ownerId: 1,
@@ -20,13 +21,13 @@ const products = [
  * Mimics a real life db table of products
  */
 export default class Products {
-  // /**
-  //  * Retrieves the existing products
-  //  * @returns {Promise - array} products
-  //  */
-  // static async getProducts() {
-  //   return products;
-  // }
+  /**
+   * Retrieves the existing products
+   * @returns {Promise - array} products
+   */
+  static async getProducts() {
+    return products;
+  }
 
   /**
    * Adds a new product to the existing record of products
@@ -38,5 +39,22 @@ export default class Products {
     product.id = products.length ? products[products.length - 1].id + 1 : 1;
     products.push(product);
     return product;
+  }
+
+  /**
+   * Retrives a single product from the record of products using its id
+   * @param {number} productId
+   * @returns {object} product
+   */
+  static async getProduct(productId) {
+    return products.find((product) => product.id == productId);
+  }
+
+  /**
+   * Deletes a product from the db using its id
+   * @param {number} productId
+   */
+  static async deleteProduct(productId) {
+    products = products.filter((product) => product.id != productId);
   }
 }

--- a/src/db/users.js
+++ b/src/db/users.js
@@ -12,12 +12,14 @@ const { adminEmail: email, adminPassword } = envVariables;
 export default class Users {
   static async getUsers() {
     const password = await bcrypt.hash(adminPassword, 10);
-    return [{
-      id: 1,
-      email,
-      password,
-      firstName: 'Olawumi',
-      lastName: 'Yusuff',
-    }];
+    return [
+      {
+        id: 1,
+        email,
+        password,
+        firstName: 'Olawumi',
+        lastName: 'Yusuff',
+      },
+    ];
   }
 }

--- a/src/middlewares/AuthMiddleware.js
+++ b/src/middlewares/AuthMiddleware.js
@@ -28,7 +28,7 @@ export default class AuthMiddleware {
 
   static validateToken(request, response, next) {
     let { headers: { authorization: token } } = request;
-    if (!token) return Responses.unauthorizedError(response, 'You need to be signed in to post a product');
+    if (!token) return Responses.unauthorizedError(response, 'You need to be signed in to perform this operation');
     if (token.startsWith('Bearer')) [, token] = token.split(' ');
     try {
       const { userId, userEmail } = jwtUtils.verifyToken(token);

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -13,5 +13,7 @@ productRouter.post('/', AuthMiddleware.validateToken, multipartMiddleware,
   ...ProductMiddleware.validateProductData(), ProductMiddleware.processImages,
   ProductController.addProduct);
 
+productRouter.delete('/:productId', AuthMiddleware.validateToken, ProductController.deleteProduct);
+
 
 export default productRouter;

--- a/src/services/cloudinaryService.js
+++ b/src/services/cloudinaryService.js
@@ -4,6 +4,17 @@ import cloudinary from '../config/cloudinaryConfig';
 
 
 /**
+ * Cleans a filename of it extension
+ * @param {string} imageName
+ * @returns {string} filename
+ */
+const ridImageNameOfExtension = (imageName) => {
+  const splitName = imageName.split('.');
+  return splitName.slice(0, splitName.length - 1).join('.');
+};
+
+
+/**
  * Defines functions that communicate with the Cloudinary API
  */
 export default class CloudinaryService {
@@ -20,8 +31,7 @@ export default class CloudinaryService {
       // Loop over and upload each image
       const results = productImages.map(async ({ path, originalFilename }) => {
         // Generate a unique filename using timestamp and original name without the extension
-        const splitName = originalFilename.split('.');
-        const fileName = `${splitName.slice(0, splitName.length - 1).join('.')}-${new Date().getTime()}`;
+        const fileName = `${ridImageNameOfExtension(originalFilename)}-${new Date().getTime()}`;
         const result = await cloudinary.uploader.upload(path, {
           folder: `mama-ologi/u${userId}`,
           public_id: fileName,
@@ -38,5 +48,18 @@ export default class CloudinaryService {
     } catch (error) {
       next(new Error('Error uploading images'));
     }
+  }
+
+  /**
+   * Deletes images from Cloudinary through the API using their public ids
+   * @param {array} imageUrls
+   */
+  static async deleteImages(imageUrls) {
+    const publicIds = imageUrls.map((url) => {
+      const imageDir = url.slice(url.indexOf('mama-ologi'));
+      return ridImageNameOfExtension(imageDir);
+    });
+
+    await cloudinary.api.delete_resources(publicIds);
   }
 }

--- a/src/tests/auth/signin.test.js
+++ b/src/tests/auth/signin.test.js
@@ -49,7 +49,8 @@ describe(signinUrl, () => {
       expect(res.body).to.be.an('object');
       expect(res.body).to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.equal(signinError);
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.equal(signinError);
     });
 
     it('should fail to log in a user with invalid password', async () => {
@@ -64,7 +65,8 @@ describe(signinUrl, () => {
       expect(res.body).to.be.an('object');
       expect(res.body).to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.equal(signinError);
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.equal(signinError);
     });
 
     it('should fail to log in a user with incorrect email', async () => {
@@ -79,7 +81,8 @@ describe(signinUrl, () => {
       expect(res.body).to.be.an('object');
       expect(res.body).to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.equal(signinError);      
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.equal(signinError);      
     });
 
     it('should fail to log in a user with incorrect password', async () => {
@@ -94,7 +97,8 @@ describe(signinUrl, () => {
       expect(res.body).to.be.an('object');
       expect(res.body).to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.equal(signinError);
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.equal(signinError);
     });
 
     it('should fail due to internal server error', async () => {

--- a/src/tests/products/createProduct.test.js
+++ b/src/tests/products/createProduct.test.js
@@ -127,7 +127,8 @@ describe(`POST ${url}`, () => {
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.be.equal('You need to be signed in to post a product');
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.be.equal('You need to be signed in to perform this operation');
     });
 
     it('should fail to create a product when invalid token supplied', async () => {
@@ -145,7 +146,8 @@ describe(`POST ${url}`, () => {
       expect(res.status).to.equal(401);
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.be.equal('Unauthorized operation, please sign in and try again');
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.be.equal('Unauthorized operation, please sign in and try again');
     });
 
     it('should fail to create a product without a title field', async () => {

--- a/src/tests/products/deleteProduct.test.js
+++ b/src/tests/products/deleteProduct.test.js
@@ -1,0 +1,239 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import cloudinary from '../../config/cloudinaryConfig';
+
+import app from '../..';
+import Products from '../../db/products';
+import jwtUtils from '../../utils/jwtUtils';
+import Users from '../../db/users';
+
+
+chai.use(chaiHttp);
+const { expect } = chai;
+const baseUrl = '/api/v1/products';
+let user;
+let userToken;
+
+before((done) => {
+  Users.getUsers()
+    .then((res) => {
+      [user] = res;
+      userToken = jwtUtils.generateToken(user);
+      done();
+    })
+    .catch((e) => done(e));
+});
+
+describe(`DELETE ${baseUrl}/:productId`, () => {
+  describe('SUCCESS', () => {
+    let product;
+    let productWithImages;
+    let cloudApiDeleterStub;
+
+    // Insert an image without images and one with images, and stub Cloudinary API before all tests
+    before((done) => {
+      Products.addProduct({
+        title: 'fake pap',
+        ownerId: user.id,
+        price: {
+          value: '1900',
+          denomination: 'USD',
+        },
+        weight: {
+          value: 20,
+          unit: 'g',
+        },
+        description: 'This is fake! You heard?! This is fake!!!',
+        images: []
+      })
+      .then((res) => {
+        product = res;
+        return Products.addProduct({
+          title: 'fake pap with images',
+          ownerId: user.id,
+          price: {
+            value: '1900',
+            denomination: 'USD',
+          },
+          weight: {
+            value: 20,
+            unit: 'g',
+          },
+          description: 'This is fake! You heard?! This is fake!!!',
+          images: ['fake-image1.png', 'fake-image2.png'],
+        })
+      })
+      .then((res) => {
+        productWithImages = res;
+        cloudApiDeleterStub = sinon.stub(cloudinary.api, 'delete_resources').resolves('done');
+        done();
+      })
+      .catch((e) => done(e));
+    });
+
+    // Restore Cloudinary API default behaviour after all tests
+    after((done) => {
+      cloudApiDeleterStub.restore();
+      done();
+    });
+
+    it('should delete a product without images successfully', async () => {
+      const res = await chai.request(app)
+        .delete(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send();
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.data.message).to.equal(`"${product.title}" successfully deleted`);
+      expect(cloudApiDeleterStub.called).to.be.false;
+    });
+
+    it('should delete a product with images successfully', async () => {
+      const res = await chai.request(app)
+        .delete(`${baseUrl}/${productWithImages.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send();
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.data.message).to.equal(`"${productWithImages.title}" successfully deleted`);
+      expect(cloudApiDeleterStub.called).to.be.true;
+    });
+  });
+
+
+  describe('FAILURE', () => {
+    let product;
+    let productWithImages;
+    let cloudApiDeleterStub;
+
+    // Insert an image without images and one with images, and stub Cloudinary API before all tests
+    before((done) => {
+      Products.addProduct({
+        title: 'fake pap',
+        ownerId: user.id,
+        price: {
+          value: '1900',
+          denomination: 'USD',
+        },
+        weight: {
+          value: 20,
+          unit: 'g',
+        },
+        description: 'This is fake! You heard?! This is fake!!!',
+        images: []
+      })
+      .then((res) => {
+        product = res;
+        return Products.addProduct({
+          title: 'fake pap with images',
+          ownerId: user.id,
+          price: {
+            value: '1900',
+            denomination: 'USD',
+          },
+          weight: {
+            value: 20,
+            unit: 'g',
+          },
+          description: 'This is fake! You heard?! This is fake!!!',
+          images: ['fake-image1.png', 'fake-image2.png'],
+        })
+      })
+      .then((res) => {
+        productWithImages = res;
+        cloudApiDeleterStub = sinon.stub(cloudinary.api, 'delete_resources').throws(new Error('Unable to delete images'));
+        done();
+      })
+      .catch((e) => done(e));
+    });
+
+    // Delete inserted test products from db and restore Cloudinary API default behaviour after all tests
+    after((done) => {
+      cloudApiDeleterStub.restore();
+      Products.deleteProduct(product.id)
+        .then(() => Products.deleteProduct(productWithImages.id))
+        .then(() => done())
+        .catch((e) => done(e));
+    });
+
+    it('should fail to delete a product with no token provided', async () => {
+      const res = await chai.request(app)
+        .delete(`${baseUrl}/${product.id}`)
+        .send();
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.error.message).to.equal('You need to be signed in to perform this operation');
+      expect(cloudApiDeleterStub.called).to.be.false;
+    });
+
+    it('should fail to delete a product with invalid token provided', async () => {
+      const res = await chai.request(app)
+        .delete(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${new Array(5).fill('kk4jcm').join('')}`)
+        .send();
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.error.message).to.equal('Unauthorized operation, please sign in and try again');
+      expect(cloudApiDeleterStub.called).to.be.false;
+    });
+
+    it('should fail to delete a product when a non-existent product id is provided', async () => {
+      const res = await chai.request(app)
+        .delete(`${baseUrl}/100000`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send();
+
+      expect(res.status).to.equal(404);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.error.message).to.equal('Product not found');
+      expect(cloudApiDeleterStub.called).to.be.false;
+    });
+
+    it("should fail to delete a product when id of the requester is not same with the product owner's",
+      async () => {
+        const differentUserToken = jwtUtils.generateToken({ id: 3, email: 'fake@gmail.com' })
+        const res = await chai.request(app)
+          .delete(`${baseUrl}/${product.id}`)
+          .set('Authorization', `Bearer ${differentUserToken}`)
+          .send();
+
+        expect(res.status).to.equal(409);
+        expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+        expect(res.body.error.message).to.equal('You are not permitted to delete the product');
+        expect(cloudApiDeleterStub.called).to.be.false;
+    });
+
+    it('should fail to delete a product when its images were not deleted successfully', async () => {
+        const res = await chai.request(app)
+          .delete(`${baseUrl}/${productWithImages.id}`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send();
+
+        const intendedProduct = await Products.getProduct(productWithImages.id);
+        expect(res.status).to.equal(500);
+        expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+        expect(res.body.error.message).to.equal('Internal server error');
+        expect(intendedProduct).to.not.be.null;
+        expect(cloudApiDeleterStub.called).to.be.true;
+    });
+  });
+})

--- a/src/utils/responseUtils.js
+++ b/src/utils/responseUtils.js
@@ -10,7 +10,7 @@ export default class Responses {
    * @returns {object} response
    */
   static unauthorizedError(response, message, code = 401) {
-    return response.status(code).json({ status: 'error', error: message });
+    return response.status(code).json({ status: 'error', error: { message } });
   }
 
   /**
@@ -33,5 +33,31 @@ export default class Responses {
    */
   static badRequestError(response, error, code = 400) {
     return response.status(code).json({ status: 'error', error });
+  }
+
+  /**
+   * Defines the specification for responses in not found error cases
+   * @param {object} response
+   * @param {string} message
+   * @returns {object} response
+   */
+  static notFoundError(response, message) {
+    return response.status(404).json({
+      status: 'error',
+      error: { message },
+    });
+  }
+
+  /**
+   * Defines the specification for responses in not forbidden error cases
+   * @param {object} response
+   * @param {string} message
+   * @returns {object} response
+   */
+  static forbiddenError(response, message) {
+    return response.status(409).json({
+      status: 'error',
+      error: { message },
+    });
   }
 }


### PR DESCRIPTION
#### What does this PR do?
Implements the endpoint from which a user can delete a product

#### Description of Task to be completed?
Build the `DELETE /api/v1/products/:productId` endpoint

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run serve`, then using Postman send DELETE requests to
  `/api/v1/products/:productId` on localhost
_key_: Port value: 3000
_key_: Params: `productId (id of the product to be deleted)`

#### Any background context you want to provide?
Admin should be able to delete a product

#### Screenshots (if appropriate)
None

#### Questions:
None