### PR TITLE
Implement Product Update Endpoint

### DIFF
--- a/src/db/products.js
+++ b/src/db/products.js
@@ -26,7 +26,7 @@ export default class Products {
    * @returns {Promise - array} products
    */
   static async getProducts() {
-    return products;
+    return [...products];
   }
 
   /**
@@ -38,7 +38,7 @@ export default class Products {
     // eslint-disable-next-line no-param-reassign
     product.id = products.length ? products[products.length - 1].id + 1 : 1;
     products.push(product);
-    return product;
+    return { ...product };
   }
 
   /**
@@ -47,7 +47,8 @@ export default class Products {
    * @returns {object} product
    */
   static async getProduct(productId) {
-    return products.find((product) => product.id == productId);
+    const product = products.find((el) => el.id == productId);
+    return product ? { ...product } : product;
   }
 
   /**
@@ -56,5 +57,22 @@ export default class Products {
    */
   static async deleteProduct(productId) {
     products = products.filter((product) => product.id != productId);
+  }
+
+  /**
+   * Updates a product
+   * @param {number} productId
+   */
+  static async updateProduct(productId, product, updatedProduct) {
+    const productIndex = products.findIndex((el) => el.id == productId);
+    const clonedProduct = { ...product };
+    Object.entries(updatedProduct).forEach(([key, value]) => {
+      if (['weight', 'price'].includes(key)) clonedProduct[key].value = value;
+      else if (key === 'priceDenomination') clonedProduct.price.denomination = value;
+      else if (key === 'weightUnit') clonedProduct.weight.unit = value;
+      else clonedProduct[key] = value;
+    });
+    products[productIndex] = clonedProduct;
+    return clonedProduct;
   }
 }

--- a/src/middlewares/AuthMiddleware.js
+++ b/src/middlewares/AuthMiddleware.js
@@ -1,7 +1,8 @@
-import { check, validationResult } from 'express-validator';
+import { validationResult } from 'express-validator';
 
 import Responses from '../utils/responseUtils';
 import jwtUtils from '../utils/jwtUtils';
+import authValidation from '../validation/authValidation';
 
 
 /**
@@ -14,8 +15,8 @@ export default class AuthMiddleware {
    */
   static validateSigninFields() {
     return [
-      check('email').isEmail(),
-      check('password').isString().isLength({ min: 8 }),
+      authValidation.email,
+      authValidation.password,
       (request, response, next) => {
         const errors = validationResult(request);
         if (!errors.isEmpty()) {

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -10,10 +10,16 @@ const productRouter = Router();
 const multipartMiddleware = multipart();
 
 productRouter.post('/', AuthMiddleware.validateToken, multipartMiddleware,
-  ...ProductMiddleware.validateProductData(), ProductMiddleware.processImages,
+  ...ProductMiddleware.validateCreateProductData(), ProductMiddleware.processImages,
   ProductController.addProduct);
 
-productRouter.delete('/:productId', AuthMiddleware.validateToken, ProductController.deleteProduct);
+productRouter.delete('/:productId', AuthMiddleware.validateToken, ProductMiddleware.validateProductExists,
+  ProductMiddleware.validateUserCanOperateProduct, ProductController.deleteProduct);
+
+productRouter.patch('/:productId', AuthMiddleware.validateToken, multipartMiddleware,
+  ProductMiddleware.validateProductExists, ProductMiddleware.validateUserCanOperateProduct,
+  ...ProductMiddleware.validateProductUpdateData(), ProductMiddleware.processImages,
+  ProductController.updateProduct);
 
 
 export default productRouter;

--- a/src/tests/products/deleteProduct.test.js
+++ b/src/tests/products/deleteProduct.test.js
@@ -216,7 +216,7 @@ describe(`DELETE ${baseUrl}/:productId`, () => {
         expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
         expect(res.body.status).to.equal('error');
         expect(res.body.error).to.be.an('object').and.to.have.keys('message');
-        expect(res.body.error.message).to.equal('You are not permitted to delete the product');
+        expect(res.body.error.message).to.equal('You are not permitted to perform this operation on the product');
         expect(cloudApiDeleterStub.called).to.be.false;
     });
 

--- a/src/tests/products/updateProduct.test.js
+++ b/src/tests/products/updateProduct.test.js
@@ -1,0 +1,597 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+
+import app from '../..';
+import jwtUtils from '../../utils/jwtUtils';
+import Users from '../../db/users';
+import Products from '../../db/products';
+import cloudinary from '../../config/cloudinaryConfig';
+
+
+chai.use(chaiHttp);
+const { expect } = chai;
+const baseUrl = '/api/v1/products';
+const splittedDir = __dirname.replace(/[\\]/g, '/').split('/');
+const testImagesDir = `${splittedDir.slice(0, splittedDir.length - 3).join('/')}/testImages`;
+const fakeCloudinaryBaseUrl = 'https://res.cloudinary.com/qausim/image/upload/v1';
+let product;
+let productWithImages;
+let userToken;
+let user;
+
+before((done) => {
+  Users.getUsers()
+    .then((res) => {
+      [user] = res;
+      userToken = jwtUtils.generateToken(user);
+
+      return Products.addProduct({
+        title: 'fake pap',
+        ownerId: user.id,
+        price: {
+          value: '1900',
+          denomination: 'USD',
+        },
+        weight: {
+          value: 20,
+          unit: 'g',
+        },
+        description: 'This is fake! You heard?! This is fake!!!',
+        images: []
+      });
+    })
+    .then((res) => {
+      product = res;
+
+      return Products.addProduct({
+        title: 'fake pap with images',
+        ownerId: user.id,
+        price: {
+          value: '1900',
+          denomination: 'USD',
+        },
+        weight: {
+          value: 20,
+          unit: 'g',
+        },
+        description: 'This is fake! You heard?! This is fake!!!',
+        images: ['fake-image1.png', 'fake-image2.png'],
+      });
+    })
+    .then((res) => {
+      productWithImages = res;
+      done();
+    })
+    .catch((e) => done(e));
+});
+
+describe(`PATCH ${baseUrl}/:productId`, () => {
+  describe('SUCCESS', () => {
+    let uploaderStub;
+    let cloudApiDeleterStub;
+  
+    before((done) => {
+      uploaderStub = sinon.stub(cloudinary.uploader, 'upload').callsFake((path, options) => {
+        return new Promise((resolve) => {
+          resolve({ secure_url: `${fakeCloudinaryBaseUrl}/${options.folder}/${options.public_id}` });
+        });
+      });
+
+      cloudApiDeleterStub = sinon.stub(cloudinary.api, 'delete_resources').resolves('done');
+      done();
+    });
+  
+    after((done) => {
+      uploaderStub.restore();
+      cloudApiDeleterStub.restore();
+      done();
+    });
+
+
+    it('should update the title of a product', async () => {
+      const newTitle = 'updated title for fake pap';
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('title', newTitle);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.title).to.equal(newTitle);
+      expect(res.body.data.id).to.equal(product.id);
+    });
+
+    it('should update the price of a product', async () => {
+      const newPrice = '120.5';
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('price', newPrice);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.price.value).to.equal(newPrice);
+      expect(res.body.data.id).to.equal(product.id);
+    });
+
+    it('should update the priceDenomination of a product', async () => {
+      const newDenomination = 'NGN';
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('priceDenomination', newDenomination);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.price.denomination).to.equal(newDenomination);
+      expect(res.body.data.id).to.equal(product.id);
+    });
+
+    it('should update the weight of a product', async () => {
+      const newWeight = '50';
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('weight', newWeight);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.weight.value).to.equal(newWeight);
+      expect(res.body.data.id).to.equal(product.id);
+    });
+
+    it('should update the weightUnit of a product', async () => {
+      const newWeightUnit = 'kg';
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('weightUnit', newWeightUnit);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.weight.unit).to.equal(newWeightUnit);
+      expect(res.body.data.id).to.equal(product.id);
+    });
+
+    it('should update the description of a product', async () => {
+      const newDescription = 'so this is me updating the fake product you get?!';
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('description', newDescription);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.description).to.equal(newDescription);
+      expect(res.body.data.id).to.equal(product.id);
+    });
+
+    it('should update the product images', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${productWithImages.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'multipart/form-data')
+        .attach('productImages', `${testImagesDir}/camera.jpg`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.images).to.have.length(1);
+      res.body.data.images.forEach((img) => {
+        expect(img).to.be.a('string').and.satisfy((url) => url.startsWith(fakeCloudinaryBaseUrl) && url.includes('camera'));
+      });
+      expect(res.body.data.id).to.equal(productWithImages.id);
+      expect(uploaderStub.called).to.be.true;
+      expect(cloudApiDeleterStub.called).to.be.true;
+    });
+  });
+
+  describe('FAILURE', () => {
+    let uploaderStub;
+    let cloudApiDeleterStub;
+  
+    before((done) => {
+      uploaderStub = sinon.stub(cloudinary.uploader, 'upload').callsFake((path, options) => {
+        return new Promise((resolve) => {
+          resolve({ secure_url: `${fakeCloudinaryBaseUrl}/${options.folder}/${options.public_id}` });
+        });
+      });
+
+      cloudApiDeleterStub = sinon.stub(cloudinary.api, 'delete_resources').resolves('done');
+      done();
+    });
+  
+    after((done) => {
+      uploaderStub.restore();
+      cloudApiDeleterStub.restore();
+      done();
+    });
+
+    it('should fail to update a product when no token supplied', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('title', 'so this should fail');
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.be.equal('You need to be signed in to perform this operation');
+    });
+
+    it('should fail to update a product when invalid token supplied', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', `Bearer ${new Array(5).fill('srw2340kd').join('')}`)
+        .set('Content-Type', 'multipart/form-data')
+        .field('title', 'this should also fail');
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.be.equal('Unauthorized operation, please sign in and try again');
+    });
+
+    it('should fail to update a product with an empty title string', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('title', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ title }) => title);
+        return error.title === 'Please enter a valid title for the product (at least 6 characters)';
+      });
+    });
+
+    it('should fail to update a product with a title string containing only spaces', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('title', '                 ');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ title }) => title);
+        return error.title === 'Please enter a valid title for the product (at least 6 characters)';
+      });
+    });
+
+    it('should fail to update a product with a title less than 6 characters', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('title', 'pap');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ title }) => title);
+        return error.title === 'Please enter a valid title for the product (at least 6 characters)';
+      });
+    });
+
+    it('should fail to update a product with a title less than 6 alphanumeric characters padded with spaces',
+      async () => {
+        const res = await chai.request(app)
+          .patch(`${baseUrl}/${product.id}`)
+          .set('Authorization', userToken)
+          .set('Content-Type', 'multipart/form-data')
+          .field('title', '  pap         ');
+
+        expect(res.status).to.equal(400);
+        expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+          const error = errors.find(({ title }) => title);
+          return error.title === 'Please enter a valid title for the product (at least 6 characters)';
+        });
+      });
+
+    it('should fail to update a product with an empty price string', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('price', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ price }) => price);
+        return error.price === 'Please enter a valid price (numeric) for the product';
+      });
+    });
+
+    it('should fail to update a product with a non-numeric price string', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('price', 'ab5');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ price }) => price);
+        return error.price === 'Please enter a valid price (numeric) for the product';
+      });
+    });
+
+    it('should fail to update a product with an empty priceDenomination string', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('priceDenomination', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ priceDenomination }) => priceDenomination);
+        return error.priceDenomination === 'Please choose a denomination for the price';
+      });
+    });
+
+    it('should fail to update a product with a priceDenomination string containing only spaces', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('priceDenomination', '        ');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ priceDenomination }) => priceDenomination);
+        return error.priceDenomination === 'Please choose a denomination for the price';
+      });
+    });
+
+    it('should fail to update a product with a priceDenomination string besides "NGN" and "USD"', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('priceDenomination', 'GHC');
+  
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ priceDenomination }) => priceDenomination);
+        return error.priceDenomination === 'Please choose a denomination for the price';
+      });
+    });
+
+    it('should fail to update a product with a non-numeric weight string', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('weight', 'ab5');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ weight }) => weight);
+        return error.weight === 'Please enter a valid weight (numeric) value for the product';
+      });
+    });
+
+    it('should fail to update a product with an empty weightUnit string', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('weightUnit', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ weightUnit }) => weightUnit);
+        return error.weightUnit === 'Please choose unit for the weight, "g" or "kg"';
+      });
+    });
+
+    it('should fail to update a product with a weightUnit string containing only spaces', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('weightUnit', '      ');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ weightUnit }) => weightUnit);
+        return error.weightUnit === 'Please choose unit for the weight, "g" or "kg"';
+      });
+    });
+
+    it('should fail to update a product with a weightUnit string besides "g" and "kg"', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('weightUnit', 'lb');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ weightUnit }) => weightUnit);
+        return error.weightUnit === 'Please choose unit for the weight, "g" or "kg"';
+      });
+    });
+
+    it('should fail to update a product with an empty description string', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('description', '');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ description }) => description);
+        return error.description === "Please provide the product's description";
+      });
+    });
+
+    it('should fail to update a product with a description string containing only spaces', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('description', '    ');
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array').and.to.satisfy((errors) => {
+        const error = errors.find(({ description }) => description);
+        return error.description === "Please provide the product's description";
+      });
+    });
+
+    it('should fail to update a product with more than 4 image files', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .attach('productImages', `${testImagesDir}/py.png`)
+        .attach('productImages', `${testImagesDir}/py2.png`)
+        .attach('productImages', `${testImagesDir}/py3.png`)
+        .attach('productImages', `${testImagesDir}/camera.jpg`)
+        .attach('productImages', `${testImagesDir}/camera2.jpg`);
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.property('message');
+      expect(res.body.error.message).to.equal('Maximum of 4 image files allowed');
+      expect(uploaderStub.called).to.be.false;
+      expect(cloudApiDeleterStub.called).to.be.false;
+      
+    });
+
+    it('should fail to update a product with a non-jpeg or non-png image', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .attach('productImages', `${testImagesDir}/py.png`)
+        .attach('productImages', `${testImagesDir}/drone3.webp`);
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.property('message');
+      expect(res.body.error.message).to.equal('Only jpeg and png images, each not greater than 2mb, are allowed');
+      expect(uploaderStub.called).to.be.false;
+      expect(cloudApiDeleterStub.called).to.be.false;
+      
+    });
+
+    it('should fail to update a product with an image greater than 2mb in size', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .attach('productImages', `${testImagesDir}/jill-heyer.jpg`);
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.property('message');
+      expect(res.body.error.message).to.equal('Only jpeg and png images, each not greater than 2mb, are allowed');
+      expect(uploaderStub.called).to.be.false;
+      expect(cloudApiDeleterStub.called).to.be.false;
+    });
+
+    it('should encounter an error updating product in database', async () => {
+      const dbStub = sinon.stub(Products, 'updateProduct').throws(new Error());
+
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .field('title', 'updating this title should fail, you know, a server error');
+        
+      expect(res.status).to.equal(500);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.property('message');
+      expect(res.body.error.message).to.equal('Internal server error');
+      expect(dbStub.called).to.be.true;
+      dbStub.restore();
+    });
+
+    it('should encounter an error while uploading images', async () => {
+      // Restore previous behaviour of Cloudinary upload API before setting a new stub
+      uploaderStub.restore();
+      uploaderStub = sinon.stub(cloudinary.uploader, 'upload').throws(new Error());
+
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${product.id}`)
+        .set('Authorization', userToken)
+        .set('Content-Type', 'multipart/form-data')
+        .attach('productImages', `${testImagesDir}/py.png`);
+
+      expect(res.status).to.equal(500);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.property('message');
+      expect(res.body.error.message).to.equal('Error uploading images');
+      expect(uploaderStub.called).to.be.true;
+    });
+  });
+});

--- a/src/validation/authValidation.js
+++ b/src/validation/authValidation.js
@@ -1,0 +1,7 @@
+import { check } from 'express-validator';
+
+
+export default {
+  email: check('email').isEmail(),
+  password: check('password').isString().isLength({ min: 8 }),
+};

--- a/src/validation/productValidation.js
+++ b/src/validation/productValidation.js
@@ -1,0 +1,42 @@
+/* eslint-disable newline-per-chained-call */
+import { body, oneOf } from 'express-validator';
+
+export const createProductValidations = {
+  title: oneOf([body('title').trim().isString().isLength({ min: 6 })],
+    'Please enter a valid title for the product (at least 6 characters)'),
+
+  price: body('price').trim().isNumeric()
+    .withMessage('Please enter a valid price (numeric) for the product'),
+
+  priceDenomination: body('priceDenomination').trim().isIn(['NGN', 'USD'])
+    .withMessage('Please choose a denomination for the price'),
+
+  weight: body('weight').trim().isNumeric()
+    .withMessage('Please enter a valid weight (numeric) value for the product'),
+
+  weightUnit: body('weightUnit').trim().isIn(['kg', 'g'])
+    .withMessage('Please choose unit for the weight, "g" or "kg"'),
+
+  description: body('description').trim().not().isEmpty()
+    .withMessage("Please provide the product's description"),
+};
+
+export const updateProductValidations = {
+  title: oneOf([body('title').if(body('title').exists()).trim().isString()
+    .isLength({ min: 6 })], 'Please enter a valid title for the product (at least 6 characters)'),
+
+  price: body('price').if(body('price').exists()).trim().isNumeric()
+    .withMessage('Please enter a valid price (numeric) for the product'),
+
+  priceDenomination: body('priceDenomination').if(body('priceDenomination').exists())
+    .trim().isIn(['NGN', 'USD']).withMessage('Please choose a denomination for the price'),
+
+  weight: body('weight').if(body('weight').exists()).trim().isNumeric()
+    .withMessage('Please enter a valid weight (numeric) value for the product'),
+
+  weightUnit: body('weightUnit').if(body('weightUnit').exists()).trim().isIn(['kg', 'g'])
+    .withMessage('Please choose unit for the weight, "g" or "kg"'),
+
+  description: body('description').if(body('description').exists()).trim().not()
+    .isEmpty().withMessage("Please provide the product's description"),
+};


### PR DESCRIPTION
#### What does this PR do?
Provides the API endpoint from which a user can update a product

#### Description of Task to be completed?
Have the `PATCH /api/v1/products/:productId` endpoint working

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send PATCH requests to
  `/api/v1/products/:productId` on localhost
_key_: Port value: 3000
_key_: Requires token authentication (Bearer token authorization in header)
_key_: Content-Type value: multipart/form-data
_key_: Request body: Any or all of `title, price, priceDenomination, weight, weightUnit, productImages, description`

#### Any background context you want to provide?
User should be able update a product

#### Screenshots (if appropriate)
None

#### Questions:
None