### PR TITLE
Implement Get Products Endpoint

### DIFF
--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -81,4 +81,29 @@ export default class ProductController {
       next(new Error());
     }
   }
+
+  /**
+   * Retrieves all existing products in the database
+   * @param {object} request
+   * @param {object} response
+   * @param {callback} next
+   */
+  static async getProducts(request, response, next) {
+    let { query: { page } } = request;
+    if (page) {
+      page = parseInt(page, 10);
+      if (!page || page <= 0) {
+        return Responses.badRequestError(response, {
+          message: 'Query parameter value for "page" must be a number greater than zero',
+        });
+      }
+    } else page = 1;
+
+    try {
+      const products = await Products.getProducts(page);
+      return Responses.success(response, products);
+    } catch (error) {
+      next(new Error());
+    }
+  }
 }

--- a/src/db/products.js
+++ b/src/db/products.js
@@ -23,9 +23,12 @@ let products = [
 export default class Products {
   /**
    * Retrieves the existing products
+   * @param {number} page
    * @returns {Promise - array} products
    */
-  static async getProducts() {
+  static async getProducts(page) {
+    const perPage = 10;
+    if (page) return products.slice((page - 1) * perPage, page * perPage - 1);
     return [...products];
   }
 

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -13,6 +13,8 @@ productRouter.post('/', AuthMiddleware.validateToken, multipartMiddleware,
   ...ProductMiddleware.validateCreateProductData(), ProductMiddleware.processImages,
   ProductController.addProduct);
 
+productRouter.get('/', ProductController.getProducts);
+
 productRouter.delete('/:productId', AuthMiddleware.validateToken, ProductMiddleware.validateProductExists,
   ProductMiddleware.validateUserCanOperateProduct, ProductController.deleteProduct);
 

--- a/src/tests/products/getProducts.test.js
+++ b/src/tests/products/getProducts.test.js
@@ -1,0 +1,84 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+
+import app from '../..';
+import Products from '../../db/products';
+
+
+const { expect } = chai;
+chai.use(chaiHttp);
+const url = '/api/v1/products';
+
+
+describe(`GET ${url}`, () => {
+  describe('SUCCESS', () => {
+    it('should get the first page (10 items) of products', async () => {
+      const res = await chai.request(app)
+        .get(url)
+        .send();
+      
+      const dbProducts = await Products.getProducts(1);
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('array');
+      expect(res.body.data).to.have.length(dbProducts.length);
+    });
+
+    it('should get an empty list for a page of products beyond the available', async () => {
+      const res = await chai.request(app)
+        .get(`${url}?page=50`)
+        .send();
+      
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('array');
+      expect(res.body.data).to.have.length(0);
+    });
+  });
+
+  describe('FAILURE', () => {
+    const queryParameterError = 'Query parameter value for "page" must be a number greater than zero';
+
+    it('should encounter an error retrieving products', async () => {
+      const dbStub = sinon.stub(Products, 'getProducts').throws(new Error());
+      const res = await chai.request(app)
+        .get(url)
+        .send();
+      
+      expect(res.status).to.equal(500);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.key('message');
+      expect(res.body.error.message).to.equal('Internal server error');
+      expect(dbStub.called).to.be.true;
+      dbStub.restore();
+    });
+
+    it('should fail to retrieve products for a non-number page query parameter value', async () => {
+      const res = await chai.request(app)
+        .get(`${url}?page=abc`)
+        .send();
+      
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.key('message');
+      expect(res.body.error.message).to.equal(queryParameterError);
+    });
+
+    it('should fail to retrieve products for a less than 1 page query parameter value', async () => {
+      const res = await chai.request(app)
+        .get(`${url}?page=0`)
+        .send();
+      
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.key('message');
+      expect(res.body.error.message).to.equal(queryParameterError);
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Provides the API endpoint from which a user can get the (paginated) list of products

#### Description of Task to be completed?
Have the `GET /api/v1/products` endpoint working

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send GET requests to
  `/api/v1/products` on localhost
_key_: Port value: 3000

#### Any background context you want to provide?
User should able to retrieve all products

#### Screenshots (if appropriate)
None

#### Questions:
None