### PR TITLE
Implement Endpoint to Retrieve a Single Product

### DIFF
--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -106,4 +106,8 @@ export default class ProductController {
       next(new Error());
     }
   }
+
+  static async getProduct(request, response) {
+    return Responses.success(response, request.product);
+  }
 }

--- a/src/middlewares/productMiddleware.js
+++ b/src/middlewares/productMiddleware.js
@@ -69,7 +69,7 @@ export default class ProductMiddlware {
    * @param {callback} next
    * @returns {object|undefined} response or undefined
    */
-  static async validateProductExists(request, response, next) {
+  static async verifyProductExists(request, response, next) {
     const { productId } = request.params;
     try {
       // Ensure the product exists else return a 404 error
@@ -79,7 +79,7 @@ export default class ProductMiddlware {
       request.product = product;
       next();
     } catch (error) {
-      next(new Error('Internal server error'));
+      next(new Error());
     }
   }
 

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -15,11 +15,13 @@ productRouter.post('/', AuthMiddleware.validateToken, multipartMiddleware,
 
 productRouter.get('/', ProductController.getProducts);
 
-productRouter.delete('/:productId', AuthMiddleware.validateToken, ProductMiddleware.validateProductExists,
+productRouter.get('/:productId', ProductMiddleware.verifyProductExists, ProductController.getProduct);
+
+productRouter.delete('/:productId', AuthMiddleware.validateToken, ProductMiddleware.verifyProductExists,
   ProductMiddleware.validateUserCanOperateProduct, ProductController.deleteProduct);
 
 productRouter.patch('/:productId', AuthMiddleware.validateToken, multipartMiddleware,
-  ProductMiddleware.validateProductExists, ProductMiddleware.validateUserCanOperateProduct,
+  ProductMiddleware.verifyProductExists, ProductMiddleware.validateUserCanOperateProduct,
   ...ProductMiddleware.validateProductUpdateData(), ProductMiddleware.processImages,
   ProductController.updateProduct);
 

--- a/src/tests/products/getSingleProduct.test.js
+++ b/src/tests/products/getSingleProduct.test.js
@@ -1,0 +1,77 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+
+import app from '../..';
+import Products from '../../db/products';
+
+
+const { expect } = chai;
+chai.use(chaiHttp);
+const baseUrl = '/api/v1/products';
+let product;
+
+before((done) => {
+  Products.getProducts()
+    .then((products) => {
+      [product, ] = products;
+      done();
+    })
+    .catch((e) => done(e));
+});
+
+
+describe(`GET ${baseUrl}`, () => {
+  describe('SUCCESS', () => {
+    it('should get a single product', async () => {
+      const res = await chai.request(app)
+        .get(`${baseUrl}/${product.id}`)
+        .send();
+      
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('object');
+      expect(res.body.data).to.have.keys('id', 'ownerId', 'title', 'price', 'weight',
+        'description', 'images');
+      expect(res.body.data.id).to.be.a('number');
+      expect(res.body.data.description).to.be.a('string');
+      expect(res.body.data.price).to.be.an('object').and.to.have.keys('value', 'denomination');
+      expect(res.body.data.price.value).to.equal(product.price.value);
+      expect(res.body.data.price.denomination).to.equal(product.price.denomination);
+      expect(res.body.data.weight).to.be.an('object').and.to.have.keys('value', 'unit');
+      expect(res.body.data.weight.value).to.equal(product.weight.value);
+      expect(res.body.data.weight.unit).to.equal(product.weight.unit);
+      expect(res.body.data.images).to.be.an('array').and.to.have.length(product.images.length);
+    });
+  });
+
+  describe('FAILURE', () => {
+    it("should fail to retrieve a product that doesn't exist", async () => {
+      const res = await chai.request(app)
+        .get(`${baseUrl}/100000`)
+        .send();
+
+      expect(res.status).to.equal(404);
+      expect(res.body).to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.have.key('message');
+      expect(res.body.error.message).to.equal('Product not found');
+    });
+
+    it('should encounter an error retrieving products', async () => {
+      const dbStub = sinon.stub(Products, 'getProduct').throws(new Error());
+      const res = await chai.request(app)
+        .get(`${baseUrl}/${product.id}`)
+        .send();
+      
+      expect(res.status).to.equal(500);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.key('message');
+      expect(res.body.error.message).to.equal('Internal server error');
+      expect(dbStub.called).to.be.true;
+      dbStub.restore();
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Provides the API endpoint from which a user can get a single product

#### Description of Task to be completed?
Have the `GET /api/v1/products/:productId` endpoint working

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send GET requests to
  `/api/v1/products/:productId` on localhost
_key_: Port value: 3000

#### Any background context you want to provide?
User should able to retrieve a single product

#### Screenshots (if appropriate)
None

#### Questions:
None