### PR TITLE
Implement specific image deletion in updates

### DIFF
--- a/src/db/products.js
+++ b/src/db/products.js
@@ -12,7 +12,7 @@ export default class Products {
    * @returns {Promise - array} products
    */
   static async getProducts(page) {
-    const perPage = page ? page * 10 : 10;
+    const perPage = page * 10;
     return dbConnection.dbConnect(`SELECT *, images[1] FROM ${productTableName} OFFSET $1 LIMIT 10`, [perPage - 10]);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ app.use((request, response, next) => {
 app.use('/', router);
 
 
-const PORT = process.env.PORT || 3001;
+const PORT = process.env.PORT || 3000;
 
 const server = http.createServer(app);
 

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ app.use((request, response, next) => {
 app.use('/', router);
 
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3001;
 
 const server = http.createServer(app);
 

--- a/src/middlewares/productMiddleware.js
+++ b/src/middlewares/productMiddleware.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /* eslint-disable newline-per-chained-call */
 import { validationResult } from 'express-validator';
 import Responses from '../utils/responseUtils';
@@ -6,6 +7,7 @@ import Products from '../db/products';
 import { createProductValidations, updateProductValidations } from '../validation/productValidation';
 
 
+const maxImageError = 'Maximum of 4 image files allowed';
 /**
  * Defines middlewares for the product routes
  */
@@ -33,19 +35,25 @@ export default class ProductMiddlware {
     ];
   }
 
-  static async deleteExistingImages(response, existingImages, productImages) {
+  /**
+   * Filters existing product images to determine which to delete and which to spare
+   * @param {array} existingImages
+   * @param {array} productImages
+   * @param {object} error
+   */
+  static filterImagesToDelete(existingImages, productImages = [], error) {
     const imagesToDelete = [];
     const sparedImages = [];
     existingImages.forEach((img) => {
       if (img.split(':')[0] === 'deleted') imagesToDelete.push(img.slice(8));
       else sparedImages.push(img);
     });
-    if (
-      productImages && existingImages.length - imagesToDelete.length + productImages.length > 4
-    ) return Responses.badRequestError(response, { message: 'Total images cannot be more than four' });
 
-    await CloudinaryService.deleteImages(imagesToDelete);
-    return sparedImages;
+    if (!(sparedImages.length + productImages.length)) {
+      error.message = 'There must be at least one image for a product';
+    } else if (sparedImages.length + productImages.length > 4) error.message = maxImageError;
+
+    return { imagesToDelete, sparedImages };
   }
 
   /**
@@ -55,30 +63,35 @@ export default class ProductMiddlware {
    * @param {callback} next
    */
   static async processImages(request, response, next) {
-    // eslint-disable-next-line prefer-const
-    let { product, files: { productImages }, body: { productImages: existingImages } } = request;
-    // If no images proceed to the controller
-    if (!(productImages)) return next();
-    // "productImages" is an array when more than one file but an object when a single file
-    // Format it to be an array in all cases
-    productImages = productImages[0] ? productImages : [productImages];
-    if (productImages.length > 4) return Responses.badRequestError(response, { message: 'Maximum of 4 image files allowed' });
-    // If there's a file type other than "jpeg" or "png", or greater than 2mb, terminate the request
-    const wrongFormatOrTooHeavy = productImages.find(({ type, size }) => !['image/jpeg', 'image/png'].includes(type)
-    || size > 2 * 1024 * 1024);
+    const { files, body: { productImages: existingImages = [] } } = request;
+    let productImages; let remainingImages = []; const errors = {};
+    if (files) productImages = files.productImages;
+    try {
+      if (existingImages.length) {
+        const { sparedImages, imagesToDelete } = ProductMiddlware
+          .filterImagesToDelete(existingImages, productImages, errors);
+        remainingImages = sparedImages;
+        if (errors.message) return Responses.badRequestError(response, errors);
+        if (imagesToDelete.length) await CloudinaryService.deleteImages(imagesToDelete);
+        request.body.images = sparedImages;
+      }
+      // If no images proceed to the controller
+      if (!(productImages)) return next();
+      // Format it to be an array in all cases
+      productImages = productImages[0] ? productImages : [productImages];
+      if (productImages.length > 4) {
+        return Responses.badRequestError(response, { message: maxImageError });
+      }
+      const wrongFormatOrTooHeavy = productImages
+        .find(({ type, size }) => !['image/jpeg', 'image/png'].includes(type) || size > 2 * 1024 * 1024);
+      if (wrongFormatOrTooHeavy) {
+        return Responses.badRequestError(response, { message: 'Only jpeg and png images, each not greater than 2mb, are allowed' });
+      }
 
-    if (wrongFormatOrTooHeavy) {
-      return Responses.badRequestError(response, { message: 'Only jpeg and png images, each not greater than 2mb, are allowed' });
+      CloudinaryService.uploadImages(request, productImages, remainingImages, next);      
+    } catch (error) {
+      next(new Error());
     }
-
-    // Delete deleted existing images if new images
-    let sparedImages = [];
-    if (product && existingImages && existingImages.length) {
-      sparedImages = await ProductMiddlware
-        .deleteExistingImages(response, existingImages, productImages);
-    }
-
-    CloudinaryService.uploadImages(request, productImages, sparedImages, next);
   }
 
   /**

--- a/src/services/cloudinaryService.js
+++ b/src/services/cloudinaryService.js
@@ -25,7 +25,7 @@ export default class CloudinaryService {
    * @param {object} request
    * @param {callback} next
    */
-  static async uploadImages(request, productImages, next) {
+  static async uploadImages(request, productImages, sparedImages, next) {
     const { user: { userId } } = request;
     try {
       // Loop over and upload each image
@@ -43,7 +43,7 @@ export default class CloudinaryService {
 
       const images = await Promise.all(results);
       // Attach the urls to the images to the request body and proceed to the controller
-      request.body.images = images.map((image) => image.secure_url);
+      request.body.images = images.map((image) => image.secure_url).concat(sparedImages);
       next();
     } catch (error) {
       next(new Error('Error uploading images'));

--- a/src/services/cloudinaryService.js
+++ b/src/services/cloudinaryService.js
@@ -61,5 +61,6 @@ export default class CloudinaryService {
     });
 
     await cloudinary.api.delete_resources(publicIds);
+    console.log('DELETED IMAGES');
   }
 }

--- a/src/tests/products/getProducts.test.js
+++ b/src/tests/products/getProducts.test.js
@@ -27,6 +27,20 @@ describe(`GET ${url}`, () => {
       expect(res.body.data).to.have.length(dbProducts.length);
     });
 
+    it('should get the first page (10 items) of products', async () => {
+      const res = await chai.request(app)
+        .get(`${url}?page=1`)
+        .send();
+      
+      const getRes = await Products.getProducts(1);
+      const { rows: dbProducts } = getRes;
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('array');
+      expect(res.body.data).to.have.length(dbProducts.length);
+    });
+
     it('should get an empty list for a page of products beyond the available', async () => {
       const res = await chai.request(app)
         .get(`${url}?page=50`)

--- a/src/tests/products/updateProduct.test.js
+++ b/src/tests/products/updateProduct.test.js
@@ -215,7 +215,11 @@ describe(`PATCH ${baseUrl}/:productId`, () => {
         .patch(`${baseUrl}/${productWithImages.id}`)
         .set('Authorization', `Bearer ${userToken}`)
         .set('Content-Type', 'multipart/form-data')
-        .attach('productImages', `${testImagesDir}/camera.jpg`);
+        .attach('productImages', `${testImagesDir}/camera.jpg`)
+        .set('productImages', 'https://cloudinary.com/qausim/image/upload/v1/whatelse.png')
+        .set('productImages', 'deleted:https://cloudinary.com/qausim/image/upload/v1/whatelse2.png');
+
+      console.log(res.body.data);
 
       expect(res.status).to.equal(200);
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');

--- a/src/tests/products/updateProduct.test.js
+++ b/src/tests/products/updateProduct.test.js
@@ -216,10 +216,6 @@ describe(`PATCH ${baseUrl}/:productId`, () => {
         .set('Authorization', `Bearer ${userToken}`)
         .set('Content-Type', 'multipart/form-data')
         .attach('productImages', `${testImagesDir}/camera.jpg`)
-        .set('productImages', 'https://cloudinary.com/qausim/image/upload/v1/whatelse.png')
-        .set('productImages', 'deleted:https://cloudinary.com/qausim/image/upload/v1/whatelse2.png');
-
-      console.log(res.body.data);
 
       expect(res.status).to.equal(200);
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
@@ -232,6 +228,28 @@ describe(`PATCH ${baseUrl}/:productId`, () => {
       });
       expect(res.body.data.id).to.equal(productWithImages.id);
       expect(uploaderStub.called).to.be.true;
+      // expect(cloudApiDeleterStub.called).to.be.true;
+    });
+    
+    it('should delete an existing product images', async () => {
+      const productImages = [
+        'https://cloudinary.com/qausim/image/upload/v1/whatelse.png',
+        'deleted:https://cloudinary.com/qausim/image/upload/v1/whatelse2.png'
+      ];
+
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${productWithImages.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ productImages });
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.have.keys('id', 'owner_id', 'title', 'price', 'weight',
+        'description', 'images', 'price_denomination', 'weight_unit');
+      expect(res.body.data.images).to.have.length(1);
+      expect(res.body.data.images[0]).to.equal(productImages[0]);
+      expect(res.body.data.id).to.equal(productWithImages.id);
       expect(cloudApiDeleterStub.called).to.be.true;
     });
   });
@@ -580,41 +598,95 @@ describe(`PATCH ${baseUrl}/:productId`, () => {
       expect(cloudApiDeleterStub.called).to.be.false;
     });
 
-    it('should encounter an error updating product in database', async () => {
-      const dbStub = sinon.stub(Products, 'updateProduct').throws(new Error());
-
+    it('should fail to update an existing product with zero images by image deletion', async () => {
       const res = await chai.request(app)
-        .patch(`${baseUrl}/${product.id}`)
-        .set('Authorization', userToken)
-        .set('Content-Type', 'multipart/form-data')
-        .field('title', 'updating this title should fail, you know, a server error');
-        
-      expect(res.status).to.equal(500);
+        .patch(`${baseUrl}/${productWithImages.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ productImages: ['deleted:https://cloudinary.com/qausim/image/upload/v1/whatelse2.png'] });
+
+      expect(res.status).to.equal(400);
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.be.an('object').and.to.have.property('message');
-      expect(res.body.error.message).to.equal('Internal server error');
-      expect(dbStub.called).to.be.true;
-      dbStub.restore();
+      expect(res.body.error).to.be.an('object').and.have.property('message');
+      expect(res.body.error.message).to.equal('There must be at least one image for a product');
+      expect(cloudApiDeleterStub.called).to.be.false;
     });
+    
+    it('should fail to update an existing product with more than four images', async () => {
+      const res = await chai.request(app)
+        .patch(`${baseUrl}/${productWithImages.id}`)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({ productImages: [
+          'https://cloudinary.com/qausim/image/upload/v1/whatelse1.png',
+          'https://cloudinary.com/qausim/image/upload/v1/whatelse2.png',
+          'https://cloudinary.com/qausim/image/upload/v1/whatelse3.png',
+          'https://cloudinary.com/qausim/image/upload/v1/whatelse4.png',
+          'https://cloudinary.com/qausim/image/upload/v1/whatelse5.png'
+        ] });
 
-    it('should encounter an error while uploading images', async () => {
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.have.property('message');
+      expect(res.body.error.message).to.equal('Maximum of 4 image files allowed');
+      expect(cloudApiDeleterStub.called).to.be.false;
+    });
+    
+    it('should encounter an error updating product in database', async () => {
+      const dbStub = sinon.stub(Products, 'updateProduct').throws(new Error());
+      
+      const res = await chai.request(app)
+      .patch(`${baseUrl}/${product.id}`)
+      .set('Authorization', userToken)
+      .set('Content-Type', 'multipart/form-data')
+        .field('title', 'updating this title should fail, you know, a server error');
+        
+        expect(res.status).to.equal(500);
+        expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object').and.to.have.property('message');
+        expect(res.body.error.message).to.equal('Internal server error');
+        expect(dbStub.called).to.be.true;
+        dbStub.restore();
+      });
+      
+      it('should encounter an error while uploading images', async () => {
       // Restore previous behaviour of Cloudinary upload API before setting a new stub
       uploaderStub.restore();
       uploaderStub = sinon.stub(cloudinary.uploader, 'upload').throws(new Error());
-
+      
       const res = await chai.request(app)
-        .patch(`${baseUrl}/${product.id}`)
+      .patch(`${baseUrl}/${product.id}`)
         .set('Authorization', userToken)
         .set('Content-Type', 'multipart/form-data')
         .attach('productImages', `${testImagesDir}/py.png`);
-
-      expect(res.status).to.equal(500);
-      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
-      expect(res.body.status).to.equal('error');
-      expect(res.body.error).to.be.an('object').and.to.have.property('message');
-      expect(res.body.error.message).to.equal('Error uploading images');
-      expect(uploaderStub.called).to.be.true;
-    });
+        
+        expect(res.status).to.equal(500);
+        expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object').and.to.have.property('message');
+        expect(res.body.error.message).to.equal('Error uploading images');
+        expect(uploaderStub.called).to.be.true;
+      });
+      
+      it('should an error while deleting existing product images', async () => {
+        cloudApiDeleterStub.restore();
+        cloudApiDeleterStub = sinon.stub(cloudinary.api, 'delete_resources').throws(new Error());
+        const res = await chai.request(app)
+          .patch(`${baseUrl}/${productWithImages.id}`)
+          .set('Authorization', `Bearer ${userToken}`)
+          .send({ productImages: [
+            'https://cloudinary.com/qausim/image/upload/v1/whatelse2.png',
+            'https://cloudinary.com/qausim/image/upload/v1/whatelse3.png',
+            'deleted:https://cloudinary.com/qausim/image/upload/v1/whatelse1.png'
+          ] });
+  
+        expect(res.status).to.equal(500);
+        expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.error).to.be.an('object').and.have.property('message');
+        expect(res.body.error.message).to.equal('Internal server error');
+        expect(cloudApiDeleterStub.called).to.be.true;
+      });
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Implement specific image deletion on the product update route

#### Description of Task to be completed?
Allow user delete some existing images on route PATCH /api/v1/products/:productId

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run server`, then using Postman send POST requests to
  `/api/v1/products/:productId` on localhost
_key_: Port value: 3000
_key_: Content-Type value: multipart/formdata
_key_: Request body: title, description, price, priceDenomination, weight, weightUnit, productImages

#### Any background context you want to provide?
Given a user wants to delete some of the existing images, user should be able to do this

#### What are the relevant pivotal tracker stories?
None

#### Screenshots (if appropriate)
None

#### Questions:
None