### PR TITLE
Implement Adding Products to Wishlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint ./src --fix",
     "start": "node build/",
     "build": "npm run clean && babel src -d build src/ -s",
-    "pretest": "NODE_ENV=test npm run migration",
+    "pretest": "NODE_ENV=test npm run undo:migration && npm run migration",
     "test": "NODE_ENV=test nyc mocha -r @babel/polyfill -r @babel/core -r @babel/register --recursive src/tests --timeout 3000 --exit",
     "posttest": "NODE_ENV=test npm run undo:migration",
     "serve": "babel-node src/",

--- a/src/controllers/AuthController.js
+++ b/src/controllers/AuthController.js
@@ -4,6 +4,7 @@ import Users from '../db/users';
 import Responses from '../utils/responseUtils';
 import jwtUtils from '../utils/jwtUtils';
 import { hashPassword } from '../utils/authUtils';
+import Products from '../db/products';
 
 
 /**
@@ -25,6 +26,8 @@ export default class AuthController {
         const { rows: [user] } = userRes;
         const verified = await bcrypt.compare(password, user.password);
         user.token = jwtUtils.generateToken(user);
+        const { rows: wishlist } = await Products.getUserWishlist(user.id);
+        user.wishlist = wishlist;
         delete user.password; delete user.role_id; delete user.id;
         if (verified) return Responses.success(response, user);
       }

--- a/src/controllers/productController.js
+++ b/src/controllers/productController.js
@@ -17,7 +17,9 @@ export default class ProductController {
     try {
       const insertRes = await Products.addProduct(request);
       const { rows: [product] } = insertRes;
-      Responses.success(response, product, 201);
+      return product ? Responses.success(response, product, 201) : Responses.forbiddenError(
+        response, 'Unable to insert product, please ensure you have appropriate access',
+      );
     } catch (error) {
       next(new Error());
     }
@@ -112,7 +114,28 @@ export default class ProductController {
     }
   }
 
-  static async getProduct(request, response) {
+  /**
+   * Send product in response
+   * @param {object} request
+   * @param {object} response
+   */
+  static getProduct(request, response) {
     return Responses.success(response, request.product);
+  }
+
+  /**
+   * Adds a product to wishlist
+   * @param {object} request
+   * @param {object} response
+   * @param {function} next
+   */
+  static async addToWishlist(request, response, next) {
+    const { user: { userId }, params: { productId }, body: { quantity } } = request;
+    try {
+      const res = await Products.addToWishlist(userId, productId, quantity);
+      return Responses.success(response, res.rows, 200);
+    } catch (error) {
+      next(new Error());
+    }
   }
 }

--- a/src/db/migration.js
+++ b/src/db/migration.js
@@ -6,6 +6,8 @@ import { hashPassword } from '../utils/authUtils';
 export const userTableName = 'users';
 export const roleTableName = 'roles';
 export const productTableName = 'products';
+export const wishlistTableName = 'wishlists';
+
 
 const { adminEmail, adminPassword: password, environtment } = envVariables;
 const customerRole = 'customer';
@@ -75,6 +77,15 @@ export const insertProductQuery = `
   ) RETURNING *;
 `;
 
+const createWishlistQuery = `
+  CREATE TABLE IF NOT EXISTS ${wishlistTableName} (
+    id BIGSERIAL PRIMARY KEY NOT NULL,
+    owner_id BIGINT REFERENCES ${userTableName} (id) NOT NULL,
+    product_id BIGINT REFERENCES ${productTableName} (id) UNIQUE NOT NULL,
+    quantity SMALLINT NOT NULL
+  );
+`;
+
 export const selectAdminId = `SELECT id FROM ${roleTableName} WHERE role = 'admin'`;
 export const selectCustomerId = `SELECT id FROM ${roleTableName} WHERE role = 'customer'`;
 
@@ -101,6 +112,7 @@ export const selectCustomerId = `SELECT id FROM ${roleTableName} WHERE role = 'c
     await dbConnection.dbConnect(createUserTableQuery(customerId));
     await dbConnection.dbConnect(insertAdminQuery, [adminEmail, adminPassword, 'Olawumi', 'Yusuff', adminId]);
     await dbConnection.dbConnect(createProductTableQuery);
+    await dbConnection.dbConnect(createWishlistQuery);
     if (environtment === 'test') await dbConnection.dbConnect(insertProductQuery, [adminId]);
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/db/undoMigration.js
+++ b/src/db/undoMigration.js
@@ -1,15 +1,21 @@
 /* eslint-disable no-console */
 import dbConnection from './dbConnection';
 
-import { userTableName, roleTableName, productTableName } from './migration';
+import {
+  userTableName, roleTableName, productTableName, wishlistTableName,
+} from './migration';
 
 
 const dropRoleTable = `DROP TABLE IF EXISTS ${roleTableName};`;
 const dropUserTable = `DROP TABLE IF EXISTS ${userTableName};`;
 const dropProductTable = `DROP TABLE IF EXISTS ${productTableName};`;
+// const dropWishlistTable = `DROP TABLE IF EXISTS ${wishlistTableName}`;
+const dropWishlistItemsTable = `DROP TABLE IF EXISTS ${wishlistTableName}`;
 
 (async () => {
   try {
+    await dbConnection.dbConnect(dropWishlistItemsTable);
+    // await dbConnection.dbConnect(dropWishlistTable);
     await dbConnection.dbConnect(dropProductTable);
     await dbConnection.dbConnect(dropUserTable);
     await dbConnection.dbConnect(dropRoleTable);

--- a/src/mock/auth.mock.js
+++ b/src/mock/auth.mock.js
@@ -1,0 +1,12 @@
+/* eslint-disable import/prefer-default-export */
+export const mockUser = {
+  email: 'qauzeem@example.com',
+  password: '12345678',
+  firstName: 'Olawumi',
+  lastName: 'Qauzeem',
+  phone: '09011223344',
+  address: 'No 39',
+  street: 'Bolakale street, Lagos',
+  state: 'Lagos',
+  country: 'Nigeria',
+};

--- a/src/mock/product.mock.js
+++ b/src/mock/product.mock.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/prefer-default-export */
+export const mockProduct1 = {
+  title: 'Yam pepper pap',
+  price: (99).toFixed(2),
+  priceDenomination: 'NGN',
+  weight: (2).toFixed(2),
+  weightUnit: 'kg',
+  description: 'Bless your tongue with nourishment',
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,6 +3,7 @@ import swaggerUI from 'swagger-ui-express';
 
 import v1Router from './v1Routes';
 import swaggerDoc from '../../swagger.json';
+import { internalServerError } from '../utils/constants';
 
 const appRouter = Router();
 
@@ -26,7 +27,7 @@ appRouter.use((error, request, response, next) => {
   response.status(error.status || 500).json({
     status: 'error',
     error: {
-      message: error.message || 'Internal server error',
+      message: error.message || internalServerError,
     },
   });
 });

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -25,5 +25,9 @@ productRouter.patch('/:productId', AuthMiddleware.validateToken, multipartMiddle
   ...ProductMiddleware.validateProductUpdateData(), ProductMiddleware.processImages,
   ProductController.updateProduct);
 
+productRouter.post('/:productId/wishlist-add', ...ProductMiddleware.validateWishlistData(),
+  AuthMiddleware.validateToken, ProductMiddleware.verifyProductExists,
+  ProductController.addToWishlist);
+
 
 export default productRouter;

--- a/src/tests/auth/signin.test.js
+++ b/src/tests/auth/signin.test.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import app from '../../index';
 import envVariables from '../../environment';
 import Users from '../../db/users';
+import { internalServerError } from '../../utils/constants';
 
 
 chai.use(chaiHttp);
@@ -103,7 +104,6 @@ describe(signinUrl, () => {
 
     it('should fail due to internal server error', async () => {
       const stub = sinon.stub(Users, 'getUser').throws(new Error());
-
       const res = await chai.request(app)
         .post(signinUrl)
         .send({
@@ -116,7 +116,7 @@ describe(signinUrl, () => {
       expect(res.body).to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
       expect(res.body.error).to.have.key('message');
-      expect(res.body.error.message).to.equal('Internal server error');
+      expect(res.body.error.message).to.equal(internalServerError);
       expect(stub.called).to.be.true;
       stub.restore();
     });

--- a/src/tests/products/createProduct.test.js
+++ b/src/tests/products/createProduct.test.js
@@ -7,6 +7,8 @@ import app from '../..';
 import jwtUtils from '../../utils/jwtUtils';
 import envVariables from '../../environment';
 import Products from '../../db/products';
+import { mockProduct1 } from '../../mock/product.mock';
+import { internalServerError } from '../../utils/constants';
 
 chai.use(chaiHttp);
 const { expect } = chai;
@@ -14,14 +16,7 @@ const url = '/api/v1/products';
 const { adminEmail } = envVariables;
 const user = { id: 1, email: adminEmail };
 const userToken = jwtUtils.generateToken(user);
-const data = {
-  title: 'Yam pepper pap',
-  price: (99).toFixed(2),
-  priceDenomination: 'NGN',
-  weight: (2).toFixed(2),
-  weightUnit: 'kg',
-  description: 'Bless your tongue with nourishment'
-};
+const data = mockProduct1;
 
 const splittedDir = __dirname.replace(/[\\]/g, '/').split('/');
 const testImagesDir = `${splittedDir.slice(0, splittedDir.length - 3).join('/')}/testImages`;
@@ -663,7 +658,7 @@ describe(`POST ${url}`, () => {
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
       expect(res.body.error).to.be.an('object').and.to.have.property('message');
-      expect(res.body.error.message).to.equal('Internal server error');
+      expect(res.body.error.message).to.equal(internalServerError);
       expect(dbStub.called).to.be.true;
       dbStub.restore();
     });

--- a/src/tests/products/deleteProduct.test.js
+++ b/src/tests/products/deleteProduct.test.js
@@ -8,6 +8,7 @@ import Products from '../../db/products';
 import jwtUtils from '../../utils/jwtUtils';
 import Users from '../../db/users';
 import envVariables from '../../environment';
+import { internalServerError } from '../../utils/constants';
 
 
 chai.use(chaiHttp);
@@ -229,7 +230,7 @@ describe(`DELETE ${baseUrl}/:productId`, () => {
         expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
         expect(res.body.status).to.equal('error');
         expect(res.body.error).to.be.an('object').and.to.have.keys('message');
-        expect(res.body.error.message).to.equal('Internal server error');
+        expect(res.body.error.message).to.equal(internalServerError);
         expect(intendedProduct).to.not.be.null;
         expect(cloudApiDeleterStub.called).to.be.true;
     });

--- a/src/tests/products/getProducts.test.js
+++ b/src/tests/products/getProducts.test.js
@@ -4,6 +4,7 @@ import sinon from 'sinon';
 
 import app from '../..';
 import Products from '../../db/products';
+import { internalServerError } from '../../utils/constants';
 
 
 const { expect } = chai;
@@ -67,7 +68,7 @@ describe(`GET ${url}`, () => {
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
       expect(res.body.error).to.be.an('object').and.to.have.key('message');
-      expect(res.body.error.message).to.equal('Internal server error');
+      expect(res.body.error.message).to.equal(internalServerError);
       expect(dbStub.called).to.be.true;
       dbStub.restore();
     });

--- a/src/tests/products/getSingleProduct.test.js
+++ b/src/tests/products/getSingleProduct.test.js
@@ -6,6 +6,7 @@ import app from '../..';
 import Products from '../../db/products';
 import dbConnection from '../../db/dbConnection';
 import { selectAdminId, insertProductQuery } from '../../db/migration';
+import { internalServerError } from '../../utils/constants';
 
 
 const { expect } = chai;
@@ -72,7 +73,7 @@ describe(`GET ${baseUrl}/:productId`, () => {
       expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
       expect(res.body.status).to.equal('error');
       expect(res.body.error).to.be.an('object').and.to.have.key('message');
-      expect(res.body.error.message).to.equal('Internal server error');
+      expect(res.body.error.message).to.equal(internalServerError);
       expect(dbStub.called).to.be.true;
       dbStub.restore();
     });

--- a/src/tests/products/insertWish.test.js
+++ b/src/tests/products/insertWish.test.js
@@ -1,0 +1,162 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../..';
+import { mockUser } from '../../mock/auth.mock';
+import dbConnection from '../../db/dbConnection';
+import { userTableName } from '../../db/migration';
+import envVariables from '../../environment';
+import { mockProduct1 } from '../../mock/product.mock';
+import jwtUtils from '../../utils/jwtUtils';
+import Products from '../../db/products';
+import Users from '../../db/users';
+import { hashPassword } from '../../utils/authUtils';
+import { quantityValidationError, internalServerError } from '../../utils/constants';
+import Sinon from 'sinon';
+
+
+chai.use(chaiHttp);
+const { expect } = chai;
+const { adminEmail, adminPassword } = envVariables;
+const v1Url = `/api/v1`;
+const productsUrl = `${v1Url}/products`;
+let user;
+let product;
+
+before((done) => {
+  Products.addProduct({ body: mockProduct1, user: { userId: 1 } })
+    .then(({ rows }) => {
+    product = rows[0];
+    return hashPassword(mockUser.password)
+  })
+  .then((password) => {
+    const [first, rest] = mockUser.email.split('@');
+    const email = [first + 199, rest].join('@');
+    return dbConnection.dbConnect(
+      `INSERT INTO ${userTableName} (
+        email, password, first_name, last_name, address, street, phone, state, country
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9
+        ) ON CONFLICT(email) DO UPDATE SET email=excluded.email RETURNING *`,
+      [
+        email, password, mockUser.firstName, mockUser.lastName,
+        mockUser.address, mockUser.street, mockUser.phone, mockUser.state, mockUser.country
+      ]);
+  })
+  .then(({ rows }) => {
+    user = rows[0];
+    user.token = jwtUtils.generateToken(user);
+    done();
+  })
+  .catch((error) => done(error));
+});
+
+describe(`${productsUrl}/:productId/wishlist-add`, () => {
+  describe('SUCCESS', () => {
+    it('should add product to user\'s wishlist', async () => {
+      const quantity = 2;
+      const res = await chai.request(app)
+        .post(`${productsUrl}/${product.id}/wishlist-add`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .send({ quantity });
+      
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('array').and.to.have.length(1);
+      expect(res.body.data[0]).to.be.an('object').and.to.have.keys(
+        'quantity', 'title', 'total_price', 'total_weight');
+      expect(res.body.data[0].quantity).to.equal(quantity);
+      expect(res.body.data[0].title).to.equal(product.title);
+      expect(res.body.data[0].total_price).to.equal((parseFloat(product.price) * quantity).toFixed(2));
+      expect(res.body.data[0].total_weight).to.equal((parseFloat(product.weight) * quantity).toFixed(2));
+    });
+    
+    it('should add update product quantity to maximum in user\'s wishlist', async () => {
+      const quantity = 4;
+      const res = await chai.request(app)
+        .post(`${productsUrl}/${product.id}/wishlist-add`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .send({ quantity });
+      
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('array').and.to.have.length(1);
+      expect(res.body.data[0]).to.be.an('object').and.to.have.keys(
+        'quantity', 'title', 'total_price', 'total_weight');
+      expect(res.body.data[0].quantity).to.equal(quantity);
+      expect(res.body.data[0].title).to.equal(product.title);
+      expect(res.body.data[0].total_price).to.equal((parseFloat(product.price) * quantity).toFixed(2));
+      expect(res.body.data[0].total_weight).to.equal((parseFloat(product.weight) * quantity).toFixed(2));
+    });
+  });
+
+  describe('FAILURE', () => {
+    it('should fail to add product to user\'s wishlist due to no token', async () => {
+      const res = await chai.request(app)
+        .post(`${productsUrl}/${product.id}/wishlist-add`)
+        .send({ quantity: 7 });
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.have.property('message');
+      expect(res.body.error.message).to.equal('You need to be signed in to perform this operation');
+    });
+    
+    it('should fail to add product to user\'s wishlist for invalid token', async () => {
+      const res = await chai.request(app)
+        .post(`${productsUrl}/${product.id}/wishlist-add`)
+        .set('Authorization', 'Bearer ' + 'ldldldld'.repeat(5))
+        .send({ quantity: 7 });
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.have.property('message');
+      expect(res.body.error.message).to.equal('Unauthorized operation, please sign in and try again');
+    });
+    
+    it('should fail to add product to user\'s wishlist for product that doesn\'t exist', async () => {
+      const res = await chai.request(app)
+        .post(`${productsUrl}/${500}/wishlist-add`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .send({ quantity: 7 });
+
+      expect(res.status).to.equal(404);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.have.property('message');
+      expect(res.body.error.message).to.equal('Product not found');
+    });
+    
+    it('should fail to add product to user\'s wishlist with invalid quantity', async () => {
+      const res = await chai.request(app)
+        .post(`${productsUrl}/${product.id}/wishlist-add`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .send({ quantity: 2.5 });
+
+      expect(res.status).to.equal(400);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('array')
+      expect(res.body.error[0]).to.be.an('object').and.have.property('quantity');
+      expect(res.body.error[0].quantity).to.equal(quantityValidationError);
+    });
+    
+    it('should fail to add product to user\'s wishlist due to error in controller', async () => {
+      const dbStub = Sinon.stub(Products, 'addToWishlist').throws(new Error());
+      const res = await chai.request(app)
+        .post(`${productsUrl}/${product.id}/wishlist-add`)
+        .set('Authorization', `Bearer ${user.token}`)
+        .send({ quantity: 8 });
+
+      expect(res.status).to.equal(500);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.have.property('message');
+      expect(res.body.error.message).to.equal(internalServerError);
+    });
+  });
+})

--- a/src/tests/products/updateProduct.test.js
+++ b/src/tests/products/updateProduct.test.js
@@ -8,6 +8,7 @@ import Users from '../../db/users';
 import Products from '../../db/products';
 import cloudinary from '../../config/cloudinaryConfig';
 import envVariables from '../../environment';
+import { internalServerError } from '../../utils/constants';
 
 
 chai.use(chaiHttp);
@@ -645,7 +646,7 @@ describe(`PATCH ${baseUrl}/:productId`, () => {
         expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
         expect(res.body.status).to.equal('error');
         expect(res.body.error).to.be.an('object').and.to.have.property('message');
-        expect(res.body.error.message).to.equal('Internal server error');
+        expect(res.body.error.message).to.equal(internalServerError);
         expect(dbStub.called).to.be.true;
         dbStub.restore();
       });
@@ -685,7 +686,7 @@ describe(`PATCH ${baseUrl}/:productId`, () => {
         expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
         expect(res.body.status).to.equal('error');
         expect(res.body.error).to.be.an('object').and.have.property('message');
-        expect(res.body.error.message).to.equal('Internal server error');
+        expect(res.body.error.message).to.equal(internalServerError);
         expect(cloudApiDeleterStub.called).to.be.true;
       });
   });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,2 @@
+export const internalServerError = 'Internal server error';
+export const quantityValidationError = 'quantity is required and should be an integer';

--- a/src/validation/productValidation.js
+++ b/src/validation/productValidation.js
@@ -1,5 +1,6 @@
 /* eslint-disable newline-per-chained-call */
 import { body, oneOf } from 'express-validator';
+import { quantityValidationError } from '../utils/constants';
 
 export const createProductValidations = {
   title: oneOf([body('title').trim().isString().isLength({ min: 6 })],
@@ -39,4 +40,8 @@ export const updateProductValidations = {
 
   description: body('description').if(body('description').exists()).trim().not()
     .isEmpty().withMessage("Please provide the product's description"),
+};
+
+export const wishlistValidation = {
+  quantity: body('quantity').isInt().withMessage(quantityValidationError),
 };


### PR DESCRIPTION
#### What does this PR do?
Provides the API endpoint from which a user can add products to wishlist

#### Description of Task to be completed?
Have the following API endpoint working
POST /api/v1/products/wishlist-add

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run start:dev`, then using Postman send POST requests to
  `/api/v1/products/wishlist-add` on localhost
_key_: Port value: 3000
_key_: Content-Type value: application/json
_key_: Request body: `quantity`
_responses_: 200, 400, 401, 409, 500

#### Any background context you want to provide?
Given a user wants to add a desired product to his/her wishlist

#### What are the relevant pivotal tracker stories?
None

#### Screenshots (if appropriate)
None

#### Questions:
None