### PR TITLE
Implement Deletion from Cart

### DIFF
--- a/src/controllers/ProductController.js
+++ b/src/controllers/ProductController.js
@@ -146,4 +146,20 @@ export default class ProductController {
       next(new Error());
     }
   }
+
+  /**
+   * Removes an item from a user's cart
+   * @param {object} request
+   * @param {object} response
+   * @param {function} next
+   */
+  static async removeFromCart(request, response, next) {
+    const { user: { userId }, params: { productId } } = request;
+    try {
+      const cart = await Products.removeFromCart(userId, productId);
+      return Responses.success(response, cart);
+    } catch (error) {
+      next(new Error());
+    }
+  }
 }

--- a/src/db/products.js
+++ b/src/db/products.js
@@ -136,7 +136,7 @@ export default class Products {
         $1, $2, $3
       ) ON CONFLICT (product_id) DO UPDATE SET quantity=GREATEST(
         ${cartTableName}.quantity, excluded.quantity
-      ) RETURNING (SELECT get_cart($1) AS cart);
+        ) RETURNING (SELECT get_cart($1) AS cart);
     `;
     return dbConnection.dbConnect(query, [userId, productId, quantity]);
   }
@@ -153,4 +153,18 @@ export default class Products {
     return cart;
   }
 
+  /**
+   * Removes an item from user's cart in the db
+   * @param {number} userId
+   * @param {number} productId
+   */
+  static async removeFromCart(userId, productId) {
+    const { rows: [{ cart }] } = await dbConnection.dbConnect(
+      `
+        DELETE FROM ${cartTableName} WHERE owner_id=$1 AND product_id=$2 RETURNING get_cart($1) AS cart
+      `,
+      [userId, productId],
+    );
+    return cart;
+  }
 }

--- a/src/routes/productRoutes.js
+++ b/src/routes/productRoutes.js
@@ -33,8 +33,9 @@ productRouter.delete('/:productId/wishlist', AuthMiddleware.validateToken,
   ProductMiddleware.verifyProductExists, ProductController.removeFromWishlist);
 
 productRouter.post('/:productId/cart', ...ProductMiddleware.validateWishlistData(),
-  AuthMiddleware.validateToken, ProductMiddleware.verifyProductExists,
-  ProductController.addToCart);
+  AuthMiddleware.validateToken, ProductMiddleware.verifyProductExists, ProductController.addToCart);
 
+productRouter.delete('/:productId/cart', AuthMiddleware.validateToken,
+  ProductMiddleware.verifyProductExists, ProductController.removeFromCart);
 
 export default productRouter;

--- a/src/tests/products/deleteFromCart.test.js
+++ b/src/tests/products/deleteFromCart.test.js
@@ -1,0 +1,117 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../../';
+import Products from '../../db/products';
+import Users from '../../db/users';
+import { mockUser } from '../../mock/user.mock';
+import jwtUtils from '../../utils/jwtUtils';
+import {
+  emptyTokenError, invalidTokenError, productNotFoundError, internalServerError
+} from '../../utils/constants';
+
+
+const fixFloat = (num) => num.toFixed(2);
+
+chai.use(chaiHttp);
+const { expect } = chai;
+const deleteFromCartBaseUrl = '/api/v1/products';
+let user;
+let products;
+let userToken;
+
+before((done) => {
+  Users.getUser(mockUser.email)
+    .then(({ rows }) => {
+      user = rows[0];
+      userToken = jwtUtils.generateToken(user);
+      return Products.getProducts(1);
+    })
+    .then(({ rows }) => {
+      products = rows.slice(0, 2);
+      return Promise.all(
+        products.map(async(product) => await Products.addToCart(user.id, product.id, 2))
+      );
+    })
+    .then(() => done())
+    .catch((error) => done(error));
+});
+
+
+describe(`DELETE ${deleteFromCartBaseUrl}`, () => {
+  describe('SUCCESS', () => {
+    it('should delete from a user\s cart successfully', async() => {
+      const res = await chai.request(app)
+        .delete(`${deleteFromCartBaseUrl}/${products[0].id}/cart`)
+        .set('Authorization', 'Bearer ' + userToken)
+        .send();
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'data');
+      expect(res.body.status).to.equal('success');
+      expect(res.body.data).to.be.an('array').and.to.have.length(1);
+      expect(res.body.data[0]).to.be.an('object').and.to.have.keys(
+        'quantity', 'total_price', 'total_weight',
+        'product_id', 'product_price', 'product_title', 'product_weight'
+      );
+      expect(res.body.data[0].product_id).to.equal(parseInt(products[1].id));
+      expect(res.body.data[0].product_title).to.equal(products[1].title);
+      expect(fixFloat(res.body.data[0].product_price)).to.equal(products[1].price);
+      expect(fixFloat(res.body.data[0].product_weight)).to.equal(products[1].weight);
+    });
+  });
+
+  describe('FAILURE', () => {
+    it('should fail to delete from a user\s cart when token no set', async() => {
+      const res = await chai.request(app)
+        .delete(`${deleteFromCartBaseUrl}/${products[1].id}/cart`)
+        .send();
+
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.error.message).to.equal(emptyTokenError);
+    });
+    
+    it('should fail to delete from a user\s cart when invalid token is set', async() => {
+      const res = await chai.request(app)
+        .delete(`${deleteFromCartBaseUrl}/${products[1].id}/cart`)
+        .set('Authorization', 'Bearer ' + 'dldldldl'.repeat(6))
+        .send();
+      
+      expect(res.status).to.equal(401);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.error.message).to.equal(invalidTokenError);
+    });
+    
+    it('should fail to delete from a user\s a product that doesn\'t exist in the DB', async() => {
+      const res = await chai.request(app)
+        .delete(`${deleteFromCartBaseUrl}/500/cart`)
+        .set('Authorization', 'Bearer ' + userToken)
+        .send();
+      
+      expect(res.status).to.equal(404);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.error.message).to.equal(productNotFoundError);
+    });
+    
+    it('should fail to delete from a user\s a product that doesn\'t exist in the cart', async() => {
+      const res = await chai.request(app)
+        .delete(`${deleteFromCartBaseUrl}/${products[0].id}/cart`)
+        .set('Authorization', 'Bearer ' + userToken)
+        .send();
+      
+      expect(res.status).to.equal(500);
+      expect(res.body).to.be.an('object').and.to.have.keys('status', 'error');
+      expect(res.body.status).to.equal('error');
+      expect(res.body.error).to.be.an('object').and.to.have.keys('message');
+      expect(res.body.error.message).to.equal(internalServerError);
+    });
+  });
+});
+

--- a/src/tests/products/deleteFromWishlist.js
+++ b/src/tests/products/deleteFromWishlist.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
 
-import app from '../../';
+import app from '../..';
 import Products from '../../db/products';
 import Users from '../../db/users';
 import { mockUser } from '../../mock/user.mock';
@@ -114,4 +114,3 @@ describe(`DELETE ${deleteFromWishlistBaseUrl}`, () => {
     });
   });
 });
-


### PR DESCRIPTION
#### What does this PR do?
Provides the API endpoint from which a user can remove a product from his/her cart

#### Description of Task to be completed?
Have the following API endpoint working
`DELETE /api/v1/products/:productId/cart`

#### How should this be manually tested?
Clone this repo, cd into it and 
- Run `npm test`
- Or run `npm run start:dev`, then using Postman send DELETE requests to
  `/api/v1/products/:productId/cart` on localhost
_key_: Port value: 3000

#### Any background context you want to provide?
Given a user has products in his/her cart, s/he should have the option of removing the product from there

#### What are the relevant pivotal tracker stories?
None

#### Screenshots (if appropriate)
None

#### Questions:
None